### PR TITLE
Be explicit and always use call-method with print-reply

### DIFF
--- a/systemd-stop-unit.bash
+++ b/systemd-stop-unit.bash
@@ -50,6 +50,7 @@ last_active_state=""
 while true; do
 	active_state=$(dbus-send --system \
 				 --print-reply \
+				 --type=method_call \
 				 --dest=org.freedesktop.systemd1 \
 				 $unit_path \
 				 org.freedesktop.DBus.Properties.Get \
@@ -68,6 +69,7 @@ while true; do
 		fi
 	else
 		dbus-send --system \
+			  --print-reply \
 			  --type=method_call \
 			  --dest=org.freedesktop.systemd1 \
 			  /org/freedesktop/systemd1 \


### PR DESCRIPTION
So apparently, if you `dbus-send` without `--print-reply`, the message is a fire-and-forget and might even get lost since dbus sees the sender being gone.
With it, the connection stays open until a replay is received and the message is sure to have arrived.
(Gemini, Perplexity and ChatGPT all tell something similar).

And indeed, testing this I have a success rate 10/10. Without it, 1/10...

`--print-reply` induces the `--type=method_call`, but just to be verbose I aligned all our dbus commands now.