### PR TITLE
Support env var override by interpreting newlines

### DIFF
--- a/start.bash
+++ b/start.bash
@@ -8,7 +8,7 @@ then
         exit 1
     else
         CONFIG_FILE=/config.conf
-        echo "$CONFIG_FILE_CONTENT" > "$CONFIG_FILE"
+        echo -e "$CONFIG_FILE_CONTENT" > "$CONFIG_FILE"
     fi
 fi
 


### PR DESCRIPTION
This allows enviroment variable overrides by using `\n`. As newlines are not supported in the balena webui.